### PR TITLE
Retain previous user-adjusted settings when changing a searched setting in SettingsFormEditor

### DIFF
--- a/packages/settingeditor/src/SettingsFormEditor.tsx
+++ b/packages/settingeditor/src/SettingsFormEditor.tsx
@@ -11,7 +11,7 @@ import { ITranslator } from '@jupyterlab/translation';
 import { FormComponent } from '@jupyterlab/ui-components';
 import {
   JSONExt,
-  PartialJSONObject,
+  // PartialJSONObject,
   ReadonlyJSONObject,
   ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
@@ -284,10 +284,10 @@ export class SettingsFormEditor extends React.Component<
         this.props.settings.schema
       )
     ) {
-      /**
-       * Only show fields that match search value.
-       */
       const filteredSchema = JSONExt.deepCopy(this.props.settings.schema);
+      // Start with the current uiSchema or an empty one
+      const uiSchema: UiSchema = { ...this.state.uiSchema };
+
       if (this.props.filteredValues?.length ?? 0 > 0) {
         for (const field in filteredSchema.properties) {
           if (
@@ -295,12 +295,36 @@ export class SettingsFormEditor extends React.Component<
               filteredSchema.properties[field].title ?? field
             )
           ) {
-            delete filteredSchema.properties[field];
+            // Hide fields using UI schema
+            uiSchema[field] = {
+              ...uiSchema[field],
+              'ui:widget': 'hidden'
+            };
+          } else {
+            // Ensure visible fields are not hidden
+            if (uiSchema[field]) {
+              delete uiSchema[field]['ui:widget'];
+              if (Object.keys(uiSchema[field]).length === 0) {
+                delete uiSchema[field];
+              }
+            }
+          }
+        }
+      } else {
+        // When no filter is active, ensure no fields are hidden
+        for (const field in uiSchema) {
+          if (uiSchema[field]['ui:widget'] === 'hidden') {
+            delete uiSchema[field]['ui:widget'];
+            if (Object.keys(uiSchema[field]).length === 0) {
+              delete uiSchema[field];
+            }
           }
         }
       }
+
       this.setState(previousState => ({
         filteredSchema,
+        uiSchema,
         formContext: {
           ...previousState.formContext,
           schema: JSONExt.deepCopy(this.props.settings.schema)
@@ -312,18 +336,7 @@ export class SettingsFormEditor extends React.Component<
   private _getFilteredFormData(
     filteredSchema?: ISettingRegistry.ISchema
   ): ReadonlyJSONObject {
-    if (!filteredSchema?.properties) {
-      return this._formData;
-    }
-    const filteredFormData = JSONExt.deepCopy(
-      this._formData as PartialJSONObject
-    );
-    for (const field in filteredFormData) {
-      if (!filteredSchema.properties[field]) {
-        delete filteredFormData[field];
-      }
-    }
-    return filteredFormData as ReadonlyJSONObject;
+    return this._formData;
   }
 
   private _debouncer: Debouncer<void, any>;


### PR DESCRIPTION
DEVS & MAINTAINERS PLEASE IGNORE!! SORRY! This is just a PR for class that is meant to show what we tried for contributing to an open project, and this is not currently solving the bug.

## References
Addresses issue #16697 on the main repo.

Other PRs addressing this issue:
https://github.com/jupyterlab/jupyterlab/pull/17540
Working solution to the bug from the issue.

https://github.com/jwjulie/jupyterlab/pull/1 
Artifacts and attempts at solving the bug through creating _fullFormData PartialJsonObject to track settings.

## Overview
The issue involves a bug where when a user accesses the settings editor, searches for a setting, toggles it, and clears the search query, settings on the same page that were previously toggled by the user and differed from the default did not keep their statuses and instead reverted to their default values.  

## Code changes

<!-- Describe the code changes and how they address the issue. -->

Modified file: `packages/settingeditor/src/SettingsFormEditor.tsx`
Functions: `_setFilteredSchema` and `_getFilteredFormData`.
My change properly saves previous user-adjusted settings, but the UI functionality that hides settings that do not matching a search query does not work entirely correctly anymore.

Settings that were visible after query entry retained their user-adjusted value while hidden settings from the same page were reverted to their defaults. My hypothesis for this bug fix was that when searching, _setFilteredSchema makes a copy of the settings schema but only includes settings matching the given query. This means that all other settings are filtered out and reset to default. So, I changed _setFilderedSchema to preserve hidden settings and not filter out settings from the copied schema. Instead, hidden settings are set with an additional field `'ui:widget': 'hidden.`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots or GIF/mp4/other video demo here. -->
Before:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/b986b3db-9140-4d3c-ba7a-4282ed742a0a" />

After:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/eff4d32c-f1e1-4666-9fe0-ec9dc17691cb" />

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLab public APIs. -->

N/A
